### PR TITLE
依存ライブラリにSpring Securityと関連ライブラリを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,17 @@ repositories {
 }
 
 dependencies {
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-	//implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	//testImplementation 'org.springframework.security:spring-security-test'
+
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
org.springframework.boot:spring-boot-starter-security
org.thymeleaf.extras:thymeleaf-extras-springsecurity5
org.springframework.security:spring-security-test

dependencies(依存するライブラリ)にあるこれらのコメントアウトを外した．