### PR TITLE
セキュリティの認証処理を実装

### DIFF
--- a/src/main/java/oit/is/z0992/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z0992/kaizi/janken/security/JankenAuthConfiguration.java
@@ -1,0 +1,78 @@
+package oit.is.z0992.kaizi.janken.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class JankenAuthConfiguration {
+
+  /**
+   * 認証処理に関する設定（誰がどのようなロールでログインできるか）
+   *
+   * @return
+   */
+  @Bean
+  public InMemoryUserDetailsManager userDetailsService() {
+    // このクラスの下部にあるPasswordEncoderを利用して，ユーザのビルダ（ログインするユーザを作成するオブジェクト）を作成する
+    UserBuilder users = User.builder();
+
+    // UserBuilder usersにユーザ名，パスワード，ロールを指定してbuildする
+    // このときパスワードはBCryptでハッシュ化されている．
+    // ハッシュ化されたパスワードを得るには，この授業のbashターミナルで下記のように末尾にユーザ名とパスワードを指定すると良い(要VPN)
+    // $ sshrun htpasswd -nbBC 10 user1 p@ss
+    UserDetails user1 = users
+        .username("user1")
+        .password("$2y$10$uzmSQ389g5phmCG831G/bO6aBFUH55R.yL6HqtsaHqkIpT7RXnAOW")
+        .roles("USER")
+        .build();
+    UserDetails user2 = users
+        .username("user2")
+        .password("$2y$10$uzmSQ389g5phmCG831G/bO6aBFUH55R.yL6HqtsaHqkIpT7RXnAOW")
+        .roles("USER")
+        .build();
+    // 生成したユーザをImMemoryUserDetailsManagerに渡す（いくつでも良い）
+    return new InMemoryUserDetailsManager(user1, user2);
+  }
+
+  /**
+   * 認可処理に関する設定（認証されたユーザがどこにアクセスできるか）
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    // Spring Securityのフォームを利用してログインを行う（自前でログインフォームを用意することも可能）
+    http.formLogin();
+
+    // http://localhost:8000/janken で始まるURLへのアクセスはログインが必要
+    // mvcMatchers().authenticated()がmvcMatchersに指定されたアクセス先に認証処理が必要であることを示す
+    // authenticated()の代わりにpermitAll()と書くと認証不要となる
+    http.authorizeHttpRequests()
+        .mvcMatchers("/janken/**").authenticated();
+
+    http.logout().logoutSuccessUrl("/"); // ログアウト時は "http://localhost:8000/" に戻る
+    return http.build();
+  }
+
+  /**
+   *
+   * UserBuilder users = User.builder();で利用するPasswordEncoderを指定する．
+   *
+   * @return BCryptPasswordEncoderを返す
+   */
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+}


### PR DESCRIPTION
springSecurityのフォームを利用する
/janken で始まるURLへのアクセス時に認証を必要とする
ログアウト時にはトップページ (http://localhost:8080/)に戻る

上記の処理を行うJankenAuthConfiguration.javaを追加.

ユーザIDがuser1とuser2のユーザを2名分追加．ロールはUSER．
パスワードはどちらも必ずisdev. 