### PR TITLE
DBの設定

### DIFF
--- a/src/main/java/oit/is/z0992/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z0992/kaizi/janken/security/JankenAuthConfiguration.java
@@ -66,6 +66,15 @@ public class JankenAuthConfiguration {
         .mvcMatchers("/janken/**").authenticated();
 
     http.logout().logoutSuccessUrl("/"); // ログアウト時は "http://localhost:8000/" に戻る
+
+    /**
+     * 以下2行はh2-consoleを利用するための設定なので，開発が完了したらコメントアウトすることが望ましい
+     * CSRFがONになっているとフォームが対応していないためアクセスできない
+     * HTTPヘッダのX-Frame-OptionsがDENYになるとiframeでlocalhostでのアプリが使えなくなるので，H2DBのWebクライアントのためだけにdisableにする必要がある
+     */
+    http.csrf().disable();
+    http.headers().frameOptions().disable();
+
     return http.build();
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,14 @@
 server.port=8080
-
+spring.sql.init.encoding=UTF-8
+spring.datasource.url=jdbc:h2:mem:janken
+# DBを永続化したければ↓のように指定する(memはインメモリなのでSpringbootを終了すると消える)
+# 参考：https://qiita.com/5zm/items/4916d517b45ca9dc5a4b
+#spring.datasource.url=jdbc:h2:./h2db/inudaisuki
+# H2DBを利用する場合のドライバ名，ユーザ名，パスワード（なし）
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled:true
+# LOG種別の指定ERROR、WARN、INFO、DEBUG、TRACE
+# 参考：https://cloud.ibm.com/docs/java?topic=java-spring-logging&locale=ja
+logging.level.root=INFO


### PR DESCRIPTION
application.propertiesにデータベース関連の設定を実施

server.portは8080とする(server.port=8080)
spring.datasource.urlはjdbc:h2:mem:jankenに変更する
h2-consoleにアクセスできるようにspring.h2.console.enabled:trueを追加しておく

JankenAuthConfiguration.javaにh2-consoleにアクセスするための設定

    http.csrf().disable();
    http.headers().frameOptions().disable();