### PR TITLE
Getリクエストで試合ページに移動する処理とview修正

### DIFF
--- a/src/main/java/oit/is/z0992/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z0992/kaizi/janken/controller/JankenController.java
@@ -107,11 +107,30 @@ public class JankenController {
     String loginUser = prin.getName();
     this.entry.addUser(loginUser);
     model.addAttribute("entry", this.entry);
+    model.addAttribute("username", loginUser);
 
     ArrayList<User> users = userMapper.selectAllByUsers();
     model.addAttribute("users", users);
 
     return "janken.html";
+  }
+
+  /**
+   * PQueryParameterにidを与えることで対戦相手を特定するので，UserMapperにidを利用してUserオブジェクトを取得するメソッドを追加する
+   *
+   * @param id
+   * @param model Thymeleafにわたすデータを保持するオブジェクト
+   * @param prin
+   * @return
+   */
+  @GetMapping("/match")
+  public String matchJanken(@RequestParam Integer id, ModelMap model, Principal prin) {
+    User aite = userMapper.selectById(id);
+
+    model.addAttribute("aite", aite);
+    model.addAttribute("username", prin.getName());
+
+    return "match.html";
   }
 
 }

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -12,32 +12,57 @@
   <h1>Janken Game!!</h1>
 
 
-
+  <!--
   <div th:if="${entry}">
     エントリー
     <ul>
-      <!--eachは所謂for each．この場合roomオブジェクトのusersフィールドにあるすべてのデータを一通り表示する
-          thが指定されているので[]が不要になる-->
+      eachは所謂for each．この場合roomオブジェクトのusersフィールドにあるすべてのデータを一通り表示する
+          thが指定されているので[]が不要になる
       <li th:each="user : ${entry.users}">[[${user}]]</li>
     </ul>
   </div>
-
+-->
+  <p>
+  <div th:if="${username}">
+    Hi [[${username}]]
+  </div>
+  </p>
+  
   <p th:if="${users}"></p>
+  <h2>エントリー</h2>
   <!--statはステータス変数
           https://www.ne.jp/asahi/hishidama/home/tech/java/spring/boot/thymeleaf/th_each.html
         -->
   <div th:each="users,stat:${users}">
     <tr>
-      <td>Index:[[${stat.index}]]</td>
+      <!--<td>Index:[[${stat.index}]]</td>
       <td>ID:[[${users.id}]]</td>
-      <td>ユーザ名:[[${users.name}]]</td>
+      -->
+      <li><a th:href="@{/match(id=${users.id})}">[[${users.name}]]</a></li>
+    </tr>
+  </div>
+  </p>
+
+  <p th:if="${matches}"></p>
+  <h2>試合結果</h2>
+  <!--statはステータス変数
+                      https://www.ne.jp/asahi/hishidama/home/tech/java/spring/boot/thymeleaf/th_each.html
+                    -->
+  <div th:each="matches,stat:${matches}">
+    <tr>
+      <td>Index:[[${stat.index}]]</td>
+      <td>ID:[[${matches.id}]]</td>
+      <td>ユーザ1:[[${matches.user1}]]</td>
+      <td>ユーザ2:[[${matches.user2}]]</td>
+      <td>ユーザ1の手:[[${matches.user1Hand}]]</td>
+      <td>ユーザ2の手:[[${matches.user2Hand}]]</td>
     </tr>
   </div>
   </p>
 
 
-  <!--
-    <p>
+
+  <!--    <p>
         <div th:if="${username}">
             Hi [[${username}]]
         </div>
@@ -65,21 +90,7 @@
     <p>
       結果 [[${result}]]
     </p>
-    <p th:if="${matches}"></p>
-    <!--statはステータス変数
-                https://www.ne.jp/asahi/hishidama/home/tech/java/spring/boot/thymeleaf/th_each.html
-              -->
-    <div th:each="matches,stat:${matches}">
-      <tr>
-        <td>Index:[[${stat.index}]]</td>
-        <td>ID:[[${matches.id}]]</td>
-        <td>ユーザ1:[[${matches.user1}]]</td>
-        <td>ユーザ2:[[${matches.user2}]]</td>
-        <td>ユーザ1の手:[[${matches.user1Hand}]]</td>
-        <td>ユーザ2の手:[[${matches.user2Hand}]]</td>
-      </tr>
-    </div>
-    </p>
+
   </div>
 
 

--- a/src/main/resources/templates/match.html
+++ b/src/main/resources/templates/match.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+
+</head>
+
+<body>
+  <div><a href="/logout">ログアウト</a></div>
+
+  <h1>Match</h1>
+
+  <div th:each="aite,stat:${aite}" th:if="${username}">
+    <h2>[[${username}]] V.S. [[${aite.name}]]</h2>
+  </div>
+</body>


### PR DESCRIPTION
エントリーのところにselectしてきたユーザ情報を置くということに画像をみてようやく気が付いたため，その修正もした．
試合結果の表示場所も変更
Hi●●も表示していなかったっぽいので，表示できるように変更

GETリクエストを利用して相手のid(userテーブルのもの)を取得し試合ページへ移動
エントリーに表示されている各ユーザを対戦相手とするGETリクエストのリンクからmatch.htmlに移動できるように実装
自分の名前はログイン情報から，相手の名前はUserMapper経由で取得してV.S.の表示をすることにした
